### PR TITLE
Update email notification for df

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ADD Makefile .
 RUN GOOS=linux make
 
 # stage 1: build image for the required packages
-FROM centos:7 as base
+FROM almalinux:8 as base
 RUN yum install -y nfs4-acl-tools sssd-client attr acl && yum clean all && rm -rf /var/cache/yum/*
 # clean up temporary files created by yum install
 RUN ( yum clean all && \


### PR DESCRIPTION
Hi @linusband 

When integrating the lab data streamer (and the uploader interface) with the new data stager, I need to improve the logic for email notification in the data stager.

The idea is to prevent sending notification if there is no recipient provided in the stager task (this is the case for automatic lab data transfer/streaming to RDR); but if the task is failed, the administration configured in the stager should always be notified.

Could you please have a review of it?  It is not too much a change.  But if necessary, I can sit together with you to go through the change.  Thanks!