### PR TITLE
cleaned up usage of /project_freenas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN ( mkdir -p /opt/stager )
 # create configuration directory 
 RUN ( mkdir -p /etc/stager/ssl )
 # expected data sources
-VOLUME ["/project", "/project_freenas", "/project_cephfs", "/home"]
+VOLUME ["/project", "/project_cephfs", "/home"]
 
 # stage 2: build image for api-server
 FROM base as api-server

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -3,10 +3,8 @@ services:
   api-server:
     volumes:
       - ${PROJECT_VOL:-/project}:/project
-      - ${PROJECT_FREENAS_VOL:-/project_freenas}:/project_freenas
       - ${PROJECT_CEPHFS_VOL:-/project_cephfs}:/project_cephfs
   worker:
     volumes:
       - ${PROJECT_VOL:-/project}:/project
-      - ${PROJECT_FREENAS_VOL:-/project_freenas}:/project_freenas
       - ${PROJECT_CEPHFS_VOL:-/project_cephfs}:/project_cephfs

--- a/docker-compose.swarm.yml
+++ b/docker-compose.swarm.yml
@@ -5,7 +5,6 @@ services:
       - /var/lib/sss/pipes:/var/lib/sss/pipes
       - /var/lib/sss/mc:/var/lib/sss/mc:ro
       - ${PROJECT_VOL:-/project}:/project
-      - ${PROJECT_FREENAS_VOL:-/project_freenas}:/project_freenas
       - ${PROJECT_CEPHFS_VOL:-/project_cephfs}:/project_cephfs
     networks:
       default:
@@ -16,7 +15,6 @@ services:
       - /var/lib/sss/pipes:/var/lib/sss/pipes
       - /var/lib/sss/mc:/var/lib/sss/mc:ro
       - ${PROJECT_VOL:-/project}:/project
-      - ${PROJECT_FREENAS_VOL:-/project_freenas}:/project_freenas
       - ${PROJECT_CEPHFS_VOL:-/project_cephfs}:/project_cephfs
     deploy:
       placement:

--- a/env.sh
+++ b/env.sh
@@ -2,7 +2,6 @@
 HOME_VOL=/tmp/home
 PROJECT_VOL=/tmp/project
 PROJECT_CEPHFS_VOL=/tmp/project_cephfs
-PROJECT_FREENAS_VOL=/tmp/project_freenas
 
 # OIDC authentication
 AUTH_SERVER=https://login.dccn.nl

--- a/print_env.sh
+++ b/print_env.sh
@@ -12,9 +12,6 @@ echo
 echo "# volume for project directory"
 echo "PROJECT_VOL=$PROJECT_VOL"
 echo
-echo "# volume for project_freenas directory"
-echo "PROJECT_FREENAS_VOL=$PROJECT_FREENAS_VOL"
-echo
 echo "# volume for project_cephfs directory"
 echo "PROJECT_CEPHFS_VOL=$PROJECT_CEPHFS_VOL"
 echo


### PR DESCRIPTION
@linusband this is just to clean up everywhere the /project_freenas is relevant.  In production, there is already no actual usage (i.e. bind-mount) of /project_freenas.